### PR TITLE
Change ordering to enable ports to come up first

### DIFF
--- a/manifests/iface/bond.pp
+++ b/manifests/iface/bond.pp
@@ -254,7 +254,7 @@ define debnet::iface::bond(
     auto            => $auto,
     allows          => $allows,
     family          => $family,
-    order           => 60 + $order,
+    order           => 61 + $order,
     iface_d         => $iface_d,
     metric          => $metric,
     hwaddress       => $hwaddress,


### PR DESCRIPTION
The ports need to come up before the bonded interface or else the
network start service will timeout waiting for slaves to join.

This was necessary in cases where the bonded interface name comes before the names of the physical interfaces, as '100-bond0' comes before '100-eth0'. This changes it to '100-bond0' and '101-eth0' respectively.
