### PR TITLE
Remove blank line to resolve LINT errors

### DIFF
--- a/manifests/iface/dhcp.pp
+++ b/manifests/iface/dhcp.pp
@@ -133,7 +133,7 @@ define debnet::iface::dhcp (
   validate_bool($auto)
   validate_array($allows)
   validate_re($family, '^inet$' )
-  
+
   debnet::iface { $ifname :
     method          => 'dhcp',
     auto            => $auto,


### PR DESCRIPTION
Fixes the build error mentioned in #11 by @rtib:

```
manifests/iface/dhcp.pp:136:trailing_whitespace:ERROR:trailing whitespace found
```
