### PR TITLE
Update iproute package name as old one removed in Ubuntu 18.04

### DIFF
--- a/manifests/iface.pp
+++ b/manifests/iface.pp
@@ -197,8 +197,8 @@ define debnet::iface (
   }
 
   if $iface_d {
-    if $::facts['lsbdistid'] == 'Debian' and
-      $::facts['lsbmajdistrelease'] =~ /!^8.*/ {
+    if $::facts['os']['family'] == 'Debian' and
+      $::facts['os']['release']['major'] =~ /!^8.*/ {
       fail('This feature is not available prior to Debian release 8.')
     }
     validate_re($iface_d, '^[a-zA-Z][a-zA-Z0-9_]*$')

--- a/manifests/iface.pp
+++ b/manifests/iface.pp
@@ -142,7 +142,6 @@ define debnet::iface (
   Variant[String, Undef] $vendor = undef,
   Variant[String, Undef] $client = undef,
 
-  #Variant[Pattern[//], Undef]
   # options for method static
   Variant[Pattern[/^(:?[0-9]{1,3}\.){3}[0-9]{1,3}$/], Undef] $address = undef,
   Variant[Pattern[/^([0-9]{1,3}\.){3}[0-9]{1,3}$|^[0-9]{1,2}$/], Integer, Undef] $netmask = undef,

--- a/manifests/iface.pp
+++ b/manifests/iface.pp
@@ -124,89 +124,61 @@
 # limitations under the License.
 #
 define debnet::iface (
-  $method,
-  $ifname = $title,
-  $auto = true,
-  $allows = [],
-  $family = 'inet',
+  Enum['loopback', 'dhcp', 'static', 'manual', 'wvdial'] $method,
+  String $ifname = $title,
+  Boolean $auto = true,
+  Array $allows = [],
+  Enum['inet'] $family = 'inet',
   $order = 0,
-  $iface_d = undef,
+  Variant[Pattern[/^[a-zA-Z][a-zA-Z0-9_]*$/], Undef] $iface_d = undef,
 
   # options for multiple methods
-  $metric = undef,
-  $hwaddress = undef,
+  Variant[Pattern[/^\d+$/], Undef] $metric = undef,
+  Variant[Pattern[/^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$/], Undef] $hwaddress = undef,
 
   # options for method dhcp
-  $hostname = undef,
-  $leasetime = undef,
-  $vendor = undef,
-  $client = undef,
+  Variant[Pattern[/^(?![0-9]+$)(?!-)[a-zA-Z0-9-]{,63}(?<!-)$/], Undef] $hostname = undef,
+  Variant[Pattern[/^\d+$/], Undef] $leasetime = undef,
+  Variant[String, Undef] $vendor = undef,
+  Variant[String, Undef] $client = undef,
 
+  #Variant[Pattern[//], Undef]
   # options for method static
-  $address = undef,
-  $netmask = undef,
-  $broadcast = undef,
-  $gateway = undef,
-  $pointopoint = undef,
-  $mtu = undef,
-  $scope = undef,
+  Variant[Pattern[/^(:?[0-9]{1,3}\.){3}[0-9]{1,3}$/], Undef] $address = undef,
+  Variant[Pattern[/^([0-9]{1,3}\.){3}[0-9]{1,3}$|^[0-9]{1,2}$/], Integer, Undef] $netmask = undef,
+  Variant[Pattern[/^([0-9]{1,3}\.){3}[0-9]{1,3}$|^[+-]$/], Undef] $broadcast = undef,
+  Variant[Pattern[/(:?[0-9]{1,3}\.){3}[0-9]{1,3}$/], Undef] $gateway = undef,
+  Variant[Pattern[/(:?[0-9]{1,3}\.){3}[0-9]{1,3}$/], Undef] $pointopoint = undef,
+  Variant[Pattern[/^\d+$/], Undef] $mtu = undef,
+  Variant[Enum['global', 'link', 'host'], Undef] $scope = undef,
 
   # up and down commands
-  $pre_ups = [],
-  $ups = [],
-  $downs = [],
-  $post_downs = [],
+  Array $pre_ups = [],
+  Array $ups = [],
+  Array $downs = [],
+  Array $post_downs = [],
 
   # auxiliary options
-  $aux_ops = {},
+  Hash $aux_ops = {},
 
   # feature-helpers
-  $tx_queue = undef,
-  $routes = {},
-  $dns_nameservers = undef,
-  $dns_search = undef,
+  Variant[Integer, Undef] $tx_queue = undef,
+  Hash $routes = {},
+  Variant[Array, Undef] $dns_nameservers = undef,
+  Variant[Array, Undef] $dns_search = undef,
 ) {
   include debnet
-
-  validate_string($ifname)
-  validate_bool($auto)
-  validate_array($allows)
-  validate_re($family, '^inet$' )
-  validate_re($method, '^loopback$|^dhcp$|^static$|^manual$|^wvdial$')
-  validate_hash($aux_ops)
-  validate_array($pre_ups)
-  validate_array($ups)
-  validate_array($downs)
-  validate_array($post_downs)
-  if $tx_queue {
-    if is_string($tx_queue) {
-      validate_re($tx_queue, '^\d+$')
-    }
-    else {
-      validate_integer($tx_queue)
-    }
-  }
-  if $routes {
-    validate_hash($routes)
-  }
-  if $dns_nameservers {
-    validate_array($dns_nameservers)
-  }
-  if $dns_search {
-    validate_array($dns_search)
-  }
 
   if $iface_d {
     if $::facts['os']['family'] == 'Debian' and
       $::facts['os']['release']['major'] =~ /!^8.*/ {
       fail('This feature is not available prior to Debian release 8.')
     }
-    validate_re($iface_d, '^[a-zA-Z][a-zA-Z0-9_]*$')
     $cfgtgt = "${debnet::params::interfaces_dir}/${iface_d}"
   } else {
     $cfgtgt = $debnet::params::interfaces_file
   }
-  validate_absolute_path($cfgtgt)
+  assert_type(Stdlib::AbsolutePath, $cfgtgt)
 
   if !defined(Concat[$cfgtgt])
   {
@@ -238,15 +210,6 @@ define debnet::iface (
       if !defined(Package[$debnet::params::dhclient_pkg]) {
         package { $debnet::params::dhclient_pkg: ensure => 'installed', }
       }
-      if $hostname { validate_re($hostname,
-        '^(?![0-9]+$)(?!-)[a-zA-Z0-9-]{,63}(?<!-)$') }
-      if $metric { validate_re($metric, '^\d+$') }
-      if $leasetime { validate_re($leasetime, '^\d+$') }
-      if $vendor { validate_string($vendor) }
-      if $client { validate_string($client) }
-      if $hwaddress {
-        validate_re($hwaddress, '^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$') }
-
       concat::fragment { "${ifname}_stanza":
         target  => $cfgtgt,
         content => template(
@@ -259,27 +222,6 @@ define debnet::iface (
     }
 
     'static' : {
-      validate_re($address, '^(:?[0-9]{1,3}\.){3}[0-9]{1,3}$')
-      if is_string($netmask) {
-        validate_re($netmask, '^([0-9]{1,3}\.){3}[0-9]{1,3}$|^[0-9]{1,2}$')
-      }
-      else {
-        validate_integer($netmask)
-      }
-      if $broadcast {
-        validate_re($broadcast, '^([0-9]{1,3}\.){3}[0-9]{1,3}$|^[+-]$')
-      }
-      if $metric { validate_re($metric, '^\d+$') }
-      if $gateway { validate_re($gateway, '(:?[0-9]{1,3}\.){3}[0-9]{1,3}$') }
-      if $pointopoint {
-        validate_re($pointopoint, '(:?[0-9]{1,3}\.){3}[0-9]{1,3}$')
-      }
-      if $hwaddress {
-        validate_re($hwaddress, '^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$')
-      }
-      if $mtu { validate_re($mtu, '^\d+$') }
-      if $scope { validate_re($scope, '^global$|^link$|^host$') }
-
       concat::fragment { "${ifname}_stanza":
         target  => $cfgtgt,
         content => template(

--- a/manifests/iface/bond.pp
+++ b/manifests/iface/bond.pp
@@ -133,8 +133,8 @@ define debnet::iface::bond(
   $iface_d = undef,
 
   # bond options
-  $ports = [],
-  $mode = 'active-backup',
+  Array $ports = [],
+  String $mode = 'active-backup',
   $miimon = 100,
   $use_carrier = true,
   $updelay = undef,
@@ -183,7 +183,6 @@ define debnet::iface::bond(
     }
   }
 
-  validate_array($ports)
   if size($ports) == 0 {
     fail('Bonding needs at least one port to be declared!')
   }

--- a/manifests/iface/loopback.pp
+++ b/manifests/iface/loopback.pp
@@ -51,10 +51,10 @@
 # limitations under the License.
 #
 define debnet::iface::loopback (
-  $ifname = $title,
-  $auto = true,
-  $allows = [],
-  $family = 'inet',
+  Enum['lo'] $ifname = $title,
+  Boolean $auto = true,
+  Array $allows = [],
+  Enum['inet'] $family = 'inet',
   $order = 0,
   $iface_d = undef,
 
@@ -69,10 +69,6 @@ define debnet::iface::loopback (
 ) {
   include debnet
 
-  validate_re($ifname, '^lo$')
-  validate_bool($auto)
-  validate_array($allows)
-  validate_re($family, '^inet$' )
   debnet::iface { $ifname:
     method     => 'loopback',
     auto       => $auto,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,7 +37,7 @@
 class debnet {
   include debnet::params
 
-  if $::facts['osfamily'] != 'Debian' {
+  if $::facts['os']['family'] != 'Debian' {
     fail('This module supports Debian based Linux distributions only.')
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,7 +33,7 @@
 class debnet::params {
   $interfaces_file = '/etc/network/interfaces'
   $interfaces_dir = '/etc/network/interfaces.d'
-  $iproute_pkg = 'iproute'
+  $iproute_pkg = 'iproute2'
   $wvdial_pkg = 'wvdial'
   $dhclient_pkg = 'isc-dhcp-client'
   $bridge_utils_pkg = 'bridge-utils'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,11 +31,11 @@
 # limitations under the License.
 #
 class debnet::params {
-  $interfaces_file  = '/etc/network/interfaces'
-  $interfaces_dir   = '/etc/network/interfaces.d'
-  $iproute_pkg      = 'iproute2'
-  $wvdial_pkg       = 'wvdial'
-  $dhclient_pkg     = 'isc-dhcp-client'
+  $interfaces_file = '/etc/network/interfaces'
+  $interfaces_dir = '/etc/network/interfaces.d'
+  $iproute_pkg = 'iproute2'
+  $wvdial_pkg = 'wvdial'
+  $dhclient_pkg = 'isc-dhcp-client'
   $bridge_utils_pkg = 'bridge-utils'
-  $ifenslave_pkg    = 'ifenslave-2.6'
+  $ifenslave_pkg = 'ifenslave-2.6'
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,11 +31,11 @@
 # limitations under the License.
 #
 class debnet::params {
-  $interfaces_file = '/etc/network/interfaces'
-  $interfaces_dir = '/etc/network/interfaces.d'
-  $iproute_pkg = 'iproute2'
-  $wvdial_pkg = 'wvdial'
-  $dhclient_pkg = 'isc-dhcp-client'
+  $interfaces_file  = '/etc/network/interfaces'
+  $interfaces_dir   = '/etc/network/interfaces.d'
+  $iproute_pkg      = 'iproute2'
+  $wvdial_pkg       = 'wvdial'
+  $dhclient_pkg     = 'isc-dhcp-client'
   $bridge_utils_pkg = 'bridge-utils'
-  $ifenslave_pkg = 'ifenslave-2.6'
+  $ifenslave_pkg    = 'ifenslave-2.6'
 }


### PR DESCRIPTION
All Deb family distros use `iproute2` and the transitional package name of `iproute` has now been removed in Ubuntu 18.04, so update the package name in the params class to match this.