### PR TITLE
support allow-hotplug instead of auto

### DIFF
--- a/templates/iface_header.erb
+++ b/templates/iface_header.erb
@@ -1,9 +1,15 @@
 # interface <%= @ifname -%> configuration
-<% if @auto == true -%>
-auto <%= @ifname %>
+<% if @allows.index('hotplug') != nil -%>
+allow-hotplug <%= @ifname %>
 <% else -%>
+<%   if @auto == true -%>
+auto <%= @ifname %>
+<%   else -%>
 <%= @ifname %>
+<%   end -%>
 <% end -%>
 <% @allows.each do |s| -%>
+<%   if s != 'hotplug' -%>
 allow-<%= s -%> <%= @ifname %>
+<%   end -%>
 <% end -%>


### PR DESCRIPTION
`auto` is an alias for `allow-auto` now, and `allow-hotplug` is [meant](https://manpages.debian.org/stretch/ifupdown/interfaces.5.en.html) to be used instead of `allow-auto` for hotplug needs.

Not supporting `allow-hotplug` can cause systemd to pause for five minutes on boot in the case where an interface can't be ready at boot time (e.g. waiting on GUI authentication on a laptop).

This commit sees if 'hotplug' is in the 'allows' array, and if so, uses it instead of 'auto'.  Then it skips 'hotplug' when other allows are present.